### PR TITLE
added `CMAKE_MODULE_PATH` to fix the cmake module not found error

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -69,6 +69,8 @@ parts:
         - extra-cmake-modules
         source: https://github.com/fcitx/fcitx5-qt.git
         source-tag: 5.0.15
+        build-environment:
+        - CMAKE_MODULE_PATH: $CRAFT_STAGE/usr/share/ECM/cmake:$CRAFT_STAGE/usr/share/ECM:$CRAFT_STAGE/usr/share${CMAKE_MODULE_PATH:+:$CMAKE_MODULE_PATH}
         build-packages:
         - cmake
         build-snaps:


### PR DESCRIPTION
As I don't know how you're planning to build this up, so, I must not comment. But, if you can kindly explain me how you want to make the architecture of the Kde content snaps, I guess I can help you with better arrangement of those, and it'll go side by side with the gnome-sdk, so, that nothing clashes with each other, when other content snaps are used like the `gaming-mesa` or my own `ffmepg`, `webkitgtk` etc